### PR TITLE
fix: Table head style in dark mode

### DIFF
--- a/src/static/css/components/.table.css
+++ b/src/static/css/components/.table.css
@@ -19,8 +19,8 @@ main>table td {
 }
 
 main>table th {
-    color: rgb(var(--background-color-data));
-    background-color: rgb(var(--text-color-data));
+    color: rgb(var(--white-data));
+    background-color: rgb(var(--black-data));
 }
 
 main>table th:first-of-type {
@@ -29,4 +29,10 @@ main>table th:first-of-type {
 
 main>table th:last-of-type {
     border-top-right-radius: 0.25rem;
+}
+
+@media (prefers-color-scheme: dark) {
+    main>table th {
+        background-color: rgba(var(--white-data), 0.1);
+    }
 }


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
The table headers use to be white in dark mode.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


